### PR TITLE
Add probe tool spindle protection

### DIFF
--- a/FluidNC/src/GCode.cpp
+++ b/FluidNC/src/GCode.cpp
@@ -38,11 +38,11 @@ static void apply_coordinate_rotation(float* coords) {
         float angle_rad = gc_state.rotation_angle * M_PI / 180.0f;
         float cos_angle = cosf(angle_rad);
         float sin_angle = sinf(angle_rad);
-        
+
         // Translate to rotation center
         float x = coords[X_AXIS] - gc_state.rotation_center[X_AXIS];
         float y = coords[Y_AXIS] - gc_state.rotation_center[Y_AXIS];
-        
+
         // Apply rotation
         coords[X_AXIS] = x * cos_angle - y * sin_angle + gc_state.rotation_center[X_AXIS];
         coords[Y_AXIS] = x * sin_angle + y * cos_angle + gc_state.rotation_center[Y_AXIS];
@@ -56,11 +56,11 @@ static void apply_coordinate_rotation_to_offset(float* offset) {
         float angle_rad = gc_state.rotation_angle * M_PI / 180.0f;
         float cos_angle = cosf(angle_rad);
         float sin_angle = sinf(angle_rad);
-        
+
         // Rotate the I,J offsets (no translation needed for offsets)
         float i = offset[X_AXIS];  // I offset
         float j = offset[Y_AXIS];  // J offset
-        
+
         offset[X_AXIS] = i * cos_angle - j * sin_angle;  // Rotated I
         offset[Y_AXIS] = i * sin_angle + j * cos_angle;  // Rotated J
     }
@@ -631,11 +631,11 @@ Error gc_execute_line(const char* input_line) {
                         break;
                     case 68:
                         gc_block.modal.coord_rotation = CoordinateRotation::Enabled;
-                        mg_word_bit = ModalGroup::MG14;
+                        mg_word_bit                   = ModalGroup::MG14;
                         break;
                     case 69:
                         gc_block.modal.coord_rotation = CoordinateRotation::Disabled;
-                        mg_word_bit = ModalGroup::MG14;
+                        mg_word_bit                   = ModalGroup::MG14;
                         break;
                     default:
                         return Error::GcodeUnsupportedCommand;  // [Unsupported G command]
@@ -1178,7 +1178,7 @@ Error gc_execute_line(const char* input_line) {
             coords[gc_block.modal.coord_select]->get(block_coord_system);
         }
     }
-    
+
     // [15.1. Handle coordinate rotation ]: Process G68/G69 parameters
     if (bitnum_is_true(command_words, ModalGroup::MG14)) {  // Check if G68/G69 called in block
         if (gc_block.modal.coord_rotation == CoordinateRotation::Enabled) {
@@ -1198,7 +1198,7 @@ Error gc_execute_line(const char* input_line) {
             }
         } else {
             // G69: Reset rotation to disabled state
-            gc_state.rotation_angle = 0.0f;
+            gc_state.rotation_angle          = 0.0f;
             gc_state.rotation_center[X_AXIS] = 0.0f;
             gc_state.rotation_center[Y_AXIS] = 0.0f;
         }
@@ -1682,7 +1682,7 @@ Error gc_execute_line(const char* input_line) {
     // NOTE: Pass zero spindle speed for all restricted laser motions.
     if (!disableLaser) {
         pl_data->spindle_speed = gc_state.spindle_speed;  // Record data for planner use.
-    }                                                     // else { pl_data->spindle_speed = 0.0; } // Initialized as zero already.
+    }  // else { pl_data->spindle_speed = 0.0; } // Initialized as zero already.
     // [5. Select tool ]: NOT SUPPORTED. Only tracks tool value.
     // [M6. Change tool ]:
     if (gc_block.modal.tool_change == ToolChange::Enable) {
@@ -1730,6 +1730,10 @@ Error gc_execute_line(const char* input_line) {
     }
     // [7. Spindle control ]:
     if (gc_state.modal.spindle != gc_block.modal.spindle) {
+        if (gc_block.modal.spindle != SpindleState::Disable && gc_state.current_tool == ProbeToolNumber) {
+            log_warn("Probe tool active - spindle command ignored");
+            gc_block.modal.spindle = SpindleState::Disable;
+        }
         // Update spindle control and apply spindle speed when enabling it in this block.
         // NOTE: All spindle state changes are synced, even in laser mode. Also, pl_data,
         // rather than gc_state, is used to manage laser state for non-laser motions.
@@ -2012,8 +2016,8 @@ Error gc_execute_line(const char* input_line) {
             gc_state.modal.spindle      = SpindleState::Disable;
             gc_state.modal.coolant      = {};
             // Reset coordinate rotation on program end for safety
-            gc_state.modal.coord_rotation = CoordinateRotation::Disabled;
-            gc_state.rotation_angle = 0.0f;
+            gc_state.modal.coord_rotation    = CoordinateRotation::Disabled;
+            gc_state.rotation_angle          = 0.0f;
             gc_state.rotation_center[X_AXIS] = 0.0f;
             gc_state.rotation_center[Y_AXIS] = 0.0f;
             if (config->_enableParkingOverrideControl) {

--- a/FluidNC/src/GCode.h
+++ b/FluidNC/src/GCode.h
@@ -193,7 +193,8 @@ enum class ToolLengthOffset : gcodenum_t {
     EnableDynamic = 431,  // G43.1
 };
 
-static const uint32_t MaxToolNumber = 99999999;
+static const uint32_t MaxToolNumber   = 99999999;
+static const uint32_t ProbeToolNumber = 99;
 
 enum class ToolChange : bool {
     Disable = 0,
@@ -278,14 +279,14 @@ struct gc_modal_t {
     ToolLengthOffset tool_length;   // {G43.1,G49}
     CoordIndex       coord_select;  // {G54,G55,G56,G57,G58,G59}
     // uint8_t control;      // {G61} NOTE: Don't track. Only default supported.
-    ProgramFlow   program_flow;  // {M0,M1,M2,M30}
-    CoolantState  coolant;       // {M7,M8,M9}
-    SpindleState  spindle;       // {M3,M4,M5}
-    ToolChange    tool_change;   // {M6}
-    SetToolNumber        set_tool_number;
-    IoControl            io_control;    // {M62, M63, M67}
-    Override             override;      // {M56}
-    CoordinateRotation   coord_rotation; // {G68,G69}
+    ProgramFlow        program_flow;  // {M0,M1,M2,M30}
+    CoolantState       coolant;       // {M7,M8,M9}
+    SpindleState       spindle;       // {M3,M4,M5}
+    ToolChange         tool_change;   // {M6}
+    SetToolNumber      set_tool_number;
+    IoControl          io_control;      // {M62, M63, M67}
+    Override           override;        // {M56}
+    CoordinateRotation coord_rotation;  // {G68,G69}
 };
 
 struct gc_values_t {
@@ -320,7 +321,7 @@ struct parser_state_t {
     // machine zero in mm. Non-persistent. Cleared upon reset and boot.
     float tool_length_offset;  // Tracks tool length offset value when enabled.
     bool  skip_blocks;         // Skipping due to flow control
-    
+
     // Coordinate rotation state (G68/G69)
     float rotation_angle;      // Rotation angle in degrees
     float rotation_center[2];  // X,Y center of rotation

--- a/FluidNC/src/Parking.cpp
+++ b/FluidNC/src/Parking.cpp
@@ -183,6 +183,10 @@ void Parking::unpark(bool restart) {
 }
 
 void Parking::restore_spindle() {
+    if (saved_spindle != SpindleState::Disable && gc_state.current_tool == ProbeToolNumber) {
+        log_warn("Probe tool active - spindle restore ignored");
+        return;
+    }
     spindle->setState(saved_spindle, saved_spindle_speed);
 }
 

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -1050,8 +1050,12 @@ static void protocol_do_spindle_override(void* incrementvp) {
         // If spindle is on, tell it the RPM has been overridden
         // When moving, the override is handled by the stepping code
         if (gc_state.modal.spindle != SpindleState::Disable && !inMotionState()) {
-            spindle->setState(gc_state.modal.spindle, gc_state.spindle_speed);
-            gc_ovr_changed();
+            if (gc_state.current_tool != ProbeToolNumber) {
+                spindle->setState(gc_state.modal.spindle, gc_state.spindle_speed);
+                gc_ovr_changed();
+            } else {
+                log_warn("Probe tool active - spindle override ignored");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- prevent spindle activation while probe tool T99 is active
- define `ProbeToolNumber` constant
- skip spindle commands when probing in gcode, protocol override, and parking restore

## Testing
- `pio test -e tests_nosan`

------
https://chatgpt.com/codex/tasks/task_e_687ba61f5d608321b46429e48daae0b5